### PR TITLE
Allow configuration of LDAP login query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ logs/
 # Cache / temp
 cache/
 tmp/
+.installed
 
 # OS files
 .DS_Store

--- a/config/config.example.php
+++ b/config/config.example.php
@@ -49,6 +49,7 @@ return [
         'bind_dn'       => '',
         'bind_password' => '', // keep your existing password
         'ignore_cert'   => true,
+        'login_query' => '(&(objectClass=user)(|(mail=%1$s)(userPrincipalName=%1$s)(proxyAddresses=smtp:%1$s)(proxyAddresses=SMTP:%1$s)))',
     ],
 
     'auth' => [

--- a/public/install/install.php
+++ b/public/install/install.php
@@ -354,6 +354,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !$installLocked) {
         $ldapPassRaw = $_POST['ldap_bind_password'] ?? '';
         $ldapPass    = $ldapPassRaw;
         $ldapIgnore  = isset($_POST['ldap_ignore_cert']);
+        $ldapLoginQuery = $_POST['ldap_login_query'];
         $authLdapEnabled   = isset($_POST['auth_ldap_enabled']);
         $authGoogleEnabled = isset($_POST['auth_google_enabled']);
         $googleClientId    = $post('google_client_id', '');
@@ -409,6 +410,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !$installLocked) {
             'bind_dn'       => $ldapBind,
             'bind_password' => $ldapPass,
             'ignore_cert'   => $ldapIgnore,
+            'login_query' => $ldapLoginQuery,
         ];
         $newConfig['auth']['ldap_enabled']           = $authLdapEnabled;
         $newConfig['auth']['google_oauth_enabled']   = $authGoogleEnabled;
@@ -875,6 +877,11 @@ $installerAppName = installer_app_name($prefillConfig);
                                     <input class="form-check-input" type="checkbox" name="ldap_ignore_cert" id="ldap_ignore_cert" <?= $pref(['ldap', 'ignore_cert'], true) ? 'checked' : '' ?>>
                                     <label class="form-check-label" for="ldap_ignore_cert">Ignore SSL certificate errors</label>
                                 </div>
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label">LDAP Login Query</label>
+                                <input type="text" name="ldap_login_query" class="form-control" value="<?= installer_h($pref(['ldap', 'login_query'], '')) ?>">
+                                <div class="form-text">Used to find LDAP accounts for login by mail adress. If LDAP login does not work, try adjusting this to work with your LDAP provider (e.g. LLDAP)</div>
                             </div>
                             <div class="col-12">
                                 <label class="form-label">LDAP/AD Administrators Group(s)</label>

--- a/public/login_process.php
+++ b/public/login_process.php
@@ -574,10 +574,11 @@ if (!@ldap_bind($ldap, $ldapCfg['bind_dn'], $ldapCfg['bind_password'])) {
 // Find user by EMAIL
 // ------------------------------------------------------------------
 $emailEsc = ldap_escape($email, '', defined('LDAP_ESCAPE_FILTER') ? LDAP_ESCAPE_FILTER : 0);
-$filter = sprintf(
-    '(&(objectClass=user)(|(mail=%1$s)(userPrincipalName=%1$s)(proxyAddresses=smtp:%1$s)(proxyAddresses=SMTP:%1$s)))',
-    $emailEsc
-);
+$ldapLoginQuery = $ldapCfg['login_query'];
+if (!$ldapLoginQuery) {
+    $redirectWithError('LDAP Login Query is not set.');
+}
+$filter = sprintf($ldapLoginQuery, $emailEsc);
 
 $attrs = [
     'distinguishedName',

--- a/public/settings.php
+++ b/public/settings.php
@@ -430,6 +430,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $ldap['bind_password'] = $ldapPassInput === '' ? ($loadedConfig['ldap']['bind_password'] ?? '') : $ldapPassInput;
     }
     $ldap['ignore_cert']   = isset($_POST['ldap_ignore_cert']);
+    $ldap['login_query']   = $post('ldap_login_query', $ldap['login_query'] ?? '');
 
     $snipe = $config['snipeit'] ?? [];
     $snipe['base_url']  = $post('snipe_base_url', $snipe['base_url'] ?? '');
@@ -1146,6 +1147,11 @@ $effectiveLogoUrl = $configuredLogoUrl !== '' ? $configuredLogoUrl : layout_defa
                                     <input class="form-check-input" type="checkbox" name="ldap_ignore_cert" id="ldap_ignore_cert" <?= $cfg(['ldap', 'ignore_cert'], false) ? 'checked' : '' ?>>
                                     <label class="form-check-label" for="ldap_ignore_cert">Ignore SSL certificate errors</label>
                                 </div>
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label">LDAP Login Query</label>
+                                <input type="text" name="ldap_login_query" class="form-control" value="<?= h($cfg(['ldap', 'login_query'], '(&(objectClass=user)(|(mail=%1$s)(userPrincipalName=%1$s)(proxyAddresses=smtp:%1$s)(proxyAddresses=SMTP:%1$s)))')) ?>">
+                                <div class="form-text">Used to find LDAP accounts for login by mail adress. If LDAP login does not work, try adjusting this to work with your LDAP provider (e.g. LLDAP)</div>
                             </div>
                             <div class="col-12">
                                 <label class="form-label">LDAP/AD Administrators Group(s)</label>


### PR DESCRIPTION
This PR adds the option to configure the LDAP query used to find accounts during the login process. This can be used to make the login process compatible with [LLDAP](https://github.com/lldap/lldap) and potentially other LDAP providers that require a modified query.

I wanted to use LLDAP for my setup, but the login wasn't working. SnipeScheduler uses this query to find user accounts: `(&(objectClass=user)(|(mail=%1$s)(userPrincipalName=%1$s)(proxyAddresses=smtp:%1$s)(proxyAddresses=SMTP:%1$s)))`. The issue for me was `(objectClass=user)`. LLDAP apparently does not put accounts in this user objectClass , so the query returned no results.
I decided that instead of an LLDAP-specific fix, it would be easier to just allow the user to configure the query in the config file, as this approach can be reused for other LDAP Providers that need similar changes.