### PR TITLE
Add option to hide footer

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -125,10 +125,11 @@ return [
 
     'app' => [
         'name' => 'SnipeScheduler',
-        'timezone' => 'Europe/Jersey',
-        'debug'    => true,
-        'base_url' => '', // optional public app base URL (used for email links, especially cron emails)
-        'logo_url' => '', // optional: full URL or relative path to logo image
+        'timezone'    => 'Europe/Jersey',
+        'debug'       => true,
+        'hide_footer' => false,
+        'base_url'    => '', // optional public app base URL (used for email links, especially cron emails)
+        'logo_url'    => '', // optional: full URL or relative path to logo image
         'primary_color' => '#660000', // main UI colour for gradients/buttons
         'date_format' => 'd/m/Y', // display format for dates (see settings for options)
         'time_format' => 'H:i', // display format for times (12/24-hour options in settings)

--- a/public/settings.php
+++ b/public/settings.php
@@ -503,6 +503,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
     $app['timezone']              = in_array($timezoneRaw, $timezoneOptions, true) ? $timezoneRaw : $currentTimezone;
     $app['debug']                 = isset($_POST['app_debug']);
+    $app['hide_footer']           = isset($_POST['hide_footer']);
     $app['base_url']              = trim((string)$post('app_base_url', $app['base_url'] ?? ''));
     $app['logo_url']              = $post('app_logo_url', $app['logo_url'] ?? '');
     if ($action === 'save' && isset($_FILES['app_logo_file']) && is_array($_FILES['app_logo_file'])) {
@@ -2177,6 +2178,12 @@ $effectiveLogoUrl = $configuredLogoUrl !== '' ? $configuredLogoUrl : layout_defa
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" name="app_debug" id="app_debug" <?= $cfg(['app', 'debug'], false) ? 'checked' : '' ?>>
                                     <label class="form-check-label" for="app_debug">Enable debug mode (more verbose errors)</label>
+                                </div>
+                            </div>
+                            <div class="col-md-4 d-flex align-items-end">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" name="hide_footer" id="hide_footer" <?= $cfg(['app', 'hide_footer'], false) ? 'checked' : '' ?>>
+                                    <label class="form-check-label" for="hide_footer">Hide footer for non-admins</label>
                                 </div>
                             </div>
                         </div>

--- a/src/layout.php
+++ b/src/layout.php
@@ -494,7 +494,8 @@ if (!function_exists('layout_footer')) {
         $versionRaw  = is_file($versionFile) ? trim((string)@file_get_contents($versionFile)) : '';
         $version     = $versionRaw !== '' ? $versionRaw : 'dev';
         $versionEsc  = htmlspecialchars($version, ENT_QUOTES, 'UTF-8');
-        $flatpickrCfg = app_flatpickr_settings(layout_cached_config());
+        $cfg = layout_cached_config();
+        $flatpickrCfg = app_flatpickr_settings($cfg);
         $flatpickrCfgJson = json_encode($flatpickrCfg, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
 
         layout_render_pending_upgrade_modal();
@@ -738,10 +739,12 @@ if (!function_exists('layout_footer')) {
 })();
 </script>
 SCRIPT;
-        echo '<footer class="text-center text-muted mt-4 small">'
-            . 'SnipeScheduler Version ' . $versionEsc . ' - Created by '
-            . '<a href="https://www.linkedin.com/in/ben-pirozzolo-76212a88" target="_blank" rel="noopener noreferrer">Ben Pirozzolo</a>'
-            . '</footer>';
+        if (!$cfg['app']['hide_footer'] || (isset($_SESSION['user']) && ($_SESSION['user']['is_admin'] || $_SESSION['user']['is_staff']))) {
+            echo '<footer class="text-center text-muted mt-4 small">'
+                . 'SnipeScheduler Version ' . $versionEsc . ' - Created by '
+                . '<a href="https://www.linkedin.com/in/ben-pirozzolo-76212a88" target="_blank" rel="noopener noreferrer">Ben Pirozzolo</a>'
+                . '</footer>';
+        }
     }
 }
 


### PR DESCRIPTION
This is only a small QoL adjustment, so I completely understand if it would not be accepted.
The footer may cause confusion (or panic) for some (of our) users. Therefore, I have added a setting that allows it to be hidden. This setting only affects anonymous or regular users. For administrators or staff members, the footer will always remain visible. This is comparable to the 'Version in footer' setting in Snipe-IT.