### PR TITLE
Add XOAUTH2 for SMTP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "pieterjanput/snipescheduler",
+    "require": {
+        "phpmailer/phpmailer": "^7.0",
+        "greew/oauth2-azure-provider": "^2.0",
+        "league/oauth2-client": "^2.9"
+    },
+    "config": { }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,805 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "2fe3c9a80586c02ffdda114b733a3888",
+    "packages": [
+        {
+            "name": "greew/oauth2-azure-provider",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/greew/oauth2-azure-provider.git",
+                "reference": "92078ba8c76003e8164da2b4c02104a833d8391b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/greew/oauth2-azure-provider/zipball/92078ba8c76003e8164da2b4c02104a833d8391b",
+                "reference": "92078ba8c76003e8164da2b4c02104a833d8391b",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/psr7": "^2.4",
+                "league/oauth2-client": "^2.6",
+                "php": "^7.3 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.64",
+                "phpunit/phpunit": "^9.5",
+                "roave/security-advisories": "dev-latest"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Greew\\OAuth2\\Client\\Provider\\": "src/Provider/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "description": "An OAuth2 client provider for Microsoft Azure to be used with thephpleague/oauth2-client",
+            "support": {
+                "issues": "https://github.com/greew/oauth2-azure-provider/issues",
+                "source": "https://github.com/greew/oauth2-azure-provider/tree/v2.0.0"
+            },
+            "time": "2024-10-15T08:12:46+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^2.3",
+                "guzzlehttp/psr7": "^2.8",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "3.0.2",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-23T22:36:01+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-22T14:34:08+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-10T16:41:02+00:00"
+        },
+        {
+            "name": "league/oauth2-client",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth2-client.git",
+                "reference": "26e8c5da4f3d78cede7021e09b1330a0fc093d5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-client/zipball/26e8c5da4f3d78cede7021e09b1330a0fc093d5e",
+                "reference": "26e8c5da4f3d78cede7021e09b1330a0fc093d5e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
+                "php": "^7.1 || >=8.0.0 <8.6.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.5",
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth2\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Bilbie",
+                    "email": "hello@alexbilbie.com",
+                    "homepage": "http://www.alexbilbie.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "homepage": "https://github.com/shadowhand",
+                    "role": "Contributor"
+                }
+            ],
+            "description": "OAuth 2.0 Client Library",
+            "keywords": [
+                "Authentication",
+                "SSO",
+                "authorization",
+                "identity",
+                "idp",
+                "oauth",
+                "oauth2",
+                "single sign on"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth2-client/issues",
+                "source": "https://github.com/thephpleague/oauth2-client/tree/2.9.0"
+            },
+            "time": "2025-11-25T22:17:17+00:00"
+        },
+        {
+            "name": "phpmailer/phpmailer",
+            "version": "v7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPMailer/PHPMailer.git",
+                "reference": "ebf1655bd5b99b3f97e1a3ec0a69e5f4cd7ea088"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/ebf1655bd5b99b3f97e1a3ec0a69e5f4cd7ea088",
+                "reference": "ebf1655bd5b99b3f97e1a3ec0a69e5f4cd7ea088",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "doctrine/annotations": "^1.2.6 || ^1.13.3",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "squizlabs/php_codesniffer": "^3.13.5",
+                "yoast/phpunit-polyfills": "^1.0.4"
+            },
+            "suggest": {
+                "decomplexity/SendOauth2": "Adapter for using XOAUTH2 authentication",
+                "directorytree/imapengine": "For uploading sent messages via IMAP, see gmail example",
+                "ext-imap": "Needed to support advanced email address parsing according to RFC822",
+                "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
+                "ext-openssl": "Needed for secure SMTP sending and DKIM signing",
+                "greew/oauth2-azure-provider": "Needed for Microsoft Azure XOAUTH2 authentication",
+                "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+                "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+                "psr/log": "For optional PSR-3 debug logging",
+                "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)",
+                "thenetworg/oauth2-azure": "Needed for Microsoft XOAUTH2 authentication"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPMailer\\PHPMailer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-only"
+            ],
+            "authors": [
+                {
+                    "name": "Marcus Bointon",
+                    "email": "phpmailer@synchromedia.co.uk"
+                },
+                {
+                    "name": "Jim Jagielski",
+                    "email": "jimjag@gmail.com"
+                },
+                {
+                    "name": "Andy Prevost",
+                    "email": "codeworxtech@users.sourceforge.net"
+                },
+                {
+                    "name": "Brent R. Matzelle"
+                }
+            ],
+            "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "support": {
+                "issues": "https://github.com/PHPMailer/PHPMailer/issues",
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Synchro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-01-09T18:02:33+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/config/config.example.php
+++ b/config/config.example.php
@@ -238,5 +238,9 @@ return [
         'auth_method'=> 'login', // login|plain|none
         'from_email' => '',
         'from_name'  => 'SnipeScheduler',
+        'tenant_id'  => '',
+        'client_id'  => '',
+        'client_secret'  => '',
+        'refresh_token'  => '',
     ],
 ];

--- a/public/settings.php
+++ b/public/settings.php
@@ -394,6 +394,12 @@ function layout_upload_logo_file(array $file, array &$errors): ?string
     return 'uploads/logos/' . $filename;
 }
 
+$code = '';
+if (isset($_GET['code'])) {
+    $code = filter_var($_GET['code'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+    $messages[] = 'Got code, please save form again';
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? 'save';
 
@@ -691,15 +697,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     unset($quickCheckout['allowed_kit_categories']);
 
     $smtp = $config['smtp'] ?? [];
-    $smtp['host']       = $post('smtp_host', $smtp['host'] ?? '');
-    $smtp['port']       = (int)$post('smtp_port', $smtp['port'] ?? 587);
-    $smtp['username']   = $post('smtp_username', $smtp['username'] ?? '');
-    $smtpPassInput      = $_POST['smtp_password'] ?? '';
-    $smtp['password']   = $smtpPassInput === '' ? ($config['smtp']['password'] ?? '') : $smtpPassInput;
-    $smtp['encryption'] = $post('smtp_encryption', $smtp['encryption'] ?? 'tls');
-    $smtp['auth_method'] = $post('smtp_auth_method', $smtp['auth_method'] ?? 'login');
-    $smtp['from_email'] = $post('smtp_from_email', $smtp['from_email'] ?? '');
-    $smtp['from_name']  = $post('smtp_from_name', $smtp['from_name'] ?? ($app['name'] ?? 'SnipeScheduler'));
+    $smtp['host']          = $post('smtp_host', $smtp['host'] ?? '');
+    $smtp['port']          = (int)$post('smtp_port', $smtp['port'] ?? 587);
+    $smtp['username']      = $post('smtp_username', $smtp['username'] ?? '');
+    $smtpPassInput         = $_POST['smtp_password'] ?? '';
+    $smtp['password']      = $smtpPassInput === '' ? ($config['smtp']['password'] ?? '') : $smtpPassInput;
+    $smtp['encryption']    = $post('smtp_encryption', $smtp['encryption'] ?? 'tls');
+    $smtp['auth_method']   = $post('smtp_auth_method', $smtp['auth_method'] ?? 'login');
+    $smtp['from_email']    = $post('smtp_from_email', $smtp['from_email'] ?? '');
+    $smtp['from_name']     = $post('smtp_from_name', $smtp['from_name'] ?? ($app['name'] ?? 'SnipeScheduler'));
+    $smtp['tenant_id']     = $post('smtp_tenant_id', $smtp['tenant_id'] ?? '');
+    $smtp['client_id']     = $post('smtp_client_id', $smtp['client_id'] ?? '');
+    $smtpClientSecret      = $_POST['smtp_client_secret'] ?? '';
+    $smtp['client_secret'] = $smtpClientSecret === '' ? ($config['smtp']['client_secret'] ?? '') : $smtpClientSecret;
+    $smtpClientRefresh     = $_POST['smtp_refresh_token'] ?? '';
+    $smtp['refresh_token'] = $smtpClientRefresh === '' ? ($config['smtp']['refresh_token'] ?? '') : $smtpClientRefresh;
 
     $newConfig = $config;
     $newConfig['db_booking'] = $db;
@@ -792,6 +804,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $errors[] = 'Could not write config.php. Check file permissions on the config/ directory.';
         } else {
             $messages[] = 'Config saved successfully.';
+            if (file_exists(__DIR__ . '/../vendor/autoload.php') && $newConfig['smtp']['auth_method'] === 'xoauth2' && (
+                    !isset($newConfig['smtp']['refresh_token']) ||
+                    $newConfig['smtp']['tenant_id'] !== $config['smtp']['tenant_id'] ||
+                    $newConfig['smtp']['client_id'] !== $config['smtp']['client_id'] ||
+                    $newConfig['smtp']['client_secret'] !== $config['smtp']['client_secret'])) {
+                require_once __DIR__ . '/../vendor/autoload.php';
+                $provider = new \League\OAuth2\Client\Provider\GenericProvider([
+                        'clientId'                => $newConfig['smtp']['client_id'],
+                        'clientSecret'            => $newConfig['smtp']['client_secret'],
+                        'redirectUri'             => 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'],
+                        'urlAuthorize'            => $post('auth_url', 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'),
+                        'urlAccessToken'          => $post('token_url', 'https://login.microsoftonline.com/common/oauth2/v2.0/token'),
+                        'urlResourceOwnerDetails' => $post('resource_url', 'https://graph.microsoft.com/v1.0/me'),
+                ]);
+                header('Location: '. $provider->getAuthorizationUrl(['scope' => [$post('scope', 'offline_access SMTP.Send')]]));
+                exit;
+            }
         }
     }
 
@@ -1306,7 +1335,7 @@ $effectiveLogoUrl = $configuredLogoUrl !== '' ? $configuredLogoUrl : layout_defa
                                 <select name="smtp_auth_method" class="form-select">
                                     <?php
                                     $auth = strtolower($cfg(['smtp', 'auth_method'], 'login'));
-                                    foreach (['login', 'plain', 'none'] as $opt) {
+                                    foreach (['login', 'plain', 'xoauth2', 'none'] as $opt) {
                                         $sel = $auth === $opt ? 'selected' : '';
                                         echo "<option value=\"{$opt}\" {$sel}>" . strtoupper($opt) . "</option>";
                                     }
@@ -1321,13 +1350,45 @@ $effectiveLogoUrl = $configuredLogoUrl !== '' ? $configuredLogoUrl : layout_defa
                                 <label class="form-label">Password</label>
                                 <input type="password" name="smtp_password" class="form-control" placeholder="Leave blank to keep">
                             </div>
-                            <div class="col-md-4">
+                            <div class="col-md-3">
                                 <label class="form-label">From email</label>
                                 <input type="email" name="smtp_from_email" class="form-control" value="<?= h($cfg(['smtp', 'from_email'], '')) ?>">
                             </div>
-                            <div class="col-md-5">
+                            <div class="col-md-3">
                                 <label class="form-label">From name</label>
                                 <input type="text" name="smtp_from_name" class="form-control" value="<?= h($cfg(['smtp', 'from_name'], $selectedAppName)) ?>">
+                            </div>
+                            <div class="col-md-6 toggle-xoath">
+                                <label class="form-label">Tenant ID</label>
+                                <input type="text" name="smtp_tenant_id" class="form-control" value="<?= h($cfg(['smtp', 'tenant_id'], '')) ?>">
+                            </div>
+                            <div class="col-md-6 toggle-xoath">
+                                <label class="form-label">Client ID</label>
+                                <input type="text" name="smtp_client_id" class="form-control" value="<?= h($cfg(['smtp', 'client_id'], '')) ?>">
+                            </div>
+                            <div class="col-md-6 toggle-xoath">
+                                <label class="form-label">Client secret</label>
+                                <input type="password" name="smtp_client_secret" class="form-control" placeholder="Leave blank to keep">
+                            </div>
+                            <div class="col-md-6 toggle-xoath">
+                                <label class="form-label">Refresh token</label>
+                                <input type="password" readonly name="smtp_refresh_token" class="form-control" placeholder="Leave blank to keep" value="<?= h($code, '') ?>">
+                            </div>
+                            <div class="col-md-6 toggle-xoath">
+                                <label class="form-label">Authorize URL</label>
+                                <input type="text" name="auth_url" class="form-control" placeholder="https://login.microsoftonline.com/common/oauth2/v2.0/authorize">
+                            </div>
+                            <div class="col-md-6 toggle-xoath">
+                                <label class="form-label">Access Token URL</label>
+                                <input type="text" name="token_url" class="form-control" placeholder="https://login.microsoftonline.com/common/oauth2/v2.0/token">
+                            </div>
+                            <div class="col-md-6 toggle-xoath">
+                                <label class="form-label">Resource Owner Details</label>
+                                <input type="text" name="resource_url" class="form-control" placeholder="https://graph.microsoft.com/v1.0/me">
+                            </div>
+                            <div class="col-md-6 toggle-xoath">
+                                <label class="form-label">Scope</label>
+                                <input type="text" name="scope" class="form-control" placeholder="offline_access SMTP.Send">
                             </div>
                         </div>
                         <div class="d-flex justify-content-between align-items-center mt-3">
@@ -2764,6 +2825,27 @@ $effectiveLogoUrl = $configuredLogoUrl !== '' ? $configuredLogoUrl : layout_defa
         } else {
             updateBlackoutRemoveButtons();
         }
+    }
+
+    const authMethod = document.querySelector('select[name="smtp_auth_method"]');
+    const xoathFields = document.getElementsByClassName('toggle-xoath');
+
+    if (authMethod) {
+        authMethod.addEventListener('change', (e) => {
+            if (xoathFields) {
+                if (e.target.value === 'xoauth2') {
+                    for (var i = 0; i < xoathFields.length; i ++) {
+                        xoathFields[i].style.display = 'block';
+                    }
+                }
+                else {
+                    for (var i = 0; i < xoathFields.length; i ++) {
+                        xoathFields[i].style.display = 'none';
+                    }
+                }
+            }
+        });
+        authMethod.dispatchEvent(new Event('change'));
     }
 })();
 </script>

--- a/src/email.php
+++ b/src/email.php
@@ -29,7 +29,7 @@ function layout_send_mail(string $toEmail, string $toName, string $subject, stri
     $user   = $smtp['username'] ?? '';
     $pass   = $smtp['password'] ?? '';
     $enc    = strtolower(trim($smtp['encryption'] ?? '')); // none|ssl|tls
-    $auth   = strtolower(trim($smtp['auth_method'] ?? 'login')); // login|plain|none
+    $auth   = strtolower(trim($smtp['auth_method'] ?? 'login')); // login|plain|xoauth2|none
     $from   = $smtp['from_email'] ?? '';
     $fromNm = trim((string)($smtp['from_name'] ?? ''));
     if ($fromNm === '') {
@@ -39,6 +39,63 @@ function layout_send_mail(string $toEmail, string $toName, string $subject, stri
     if ($host === '' || $from === '') {
         error_log('SnipeScheduler SMTP not configured (host/from missing).');
         return false;
+    }
+
+    if ($auth === 'xoauth2') {
+        if (!isset($smtp['tenant_id'], $smtp['client_id'], $smtp['client_secret'])) {
+            error_log('SnipeScheduler SMTP not configured (tenant_id/client_id/client_secret missing).');
+            return false;
+        }
+        if (!file_exists( __DIR__ . '/../vendor/autoload.php')) {
+            error_log('Vendor not found.');
+            return false;
+        }
+        require_once __DIR__ . '/../vendor/autoload.php';
+        $mail = new PHPMailer\PHPMailer\PHPMailer();
+        $mail->isSMTP();
+        $mail->Host = $host;
+        $mail->Port = $port;
+        $mail->SMTPSecure = $enc;
+        $mail->SMTPAuth = true;
+        $mail->AuthType = strtoupper($auth);
+        $provider = new Greew\OAuth2\Client\Provider\Azure([
+            'tenantId' => $smtp['tenant_id'],
+            'clientId' => $smtp['client_id'],
+            'clientSecret' => $smtp['client_secret'],
+        ]);
+        $mail->setOAuth(
+            new PHPMailer\PHPMailer\OAuth(
+                [
+                    'provider' => $provider,
+                    'clientId' => $smtp['client_id'],
+                    'clientSecret' => $smtp['client_secret'],
+                    'refreshToken' => $smtp['refresh_token'],
+                    'userName' => $user,
+                ]
+            )
+        );
+        $mail->addAddress($toEmail, $toName);
+        $mail->Subject = $subject;
+        $mail->setFrom($from, $fromNm);
+        if ($htmlBody) {
+            $mail->isHTML();
+            $mail->Body = $htmlBody;
+        }
+        else {
+            $mail->isHTML(false);
+            $mail->Body = $body;
+        }
+        try {
+            if ($mail->send()) {
+                return true;
+            }
+            error_log('SnipeScheduler SMTP send failed: ' . $mail->ErrorInfo);
+            return false;
+        }
+        catch (Exception $e) {
+            error_log('SnipeScheduler SMTP send failed: ' . $e->getMessage());
+            return false;
+        }
     }
 
     $remoteHost = ($enc === 'ssl') ? "ssl://{$host}" : $host; // STARTTLS uses plain host, SSL wraps immediately


### PR DESCRIPTION
This change makes it possible to use XOAUTH2 as the authentication method for sending emails via SMTP. For now, this has only been tested with Office 365.
When selecting XOAUTH2, the user must provide a Tenant ID, Client ID, and Client Secret. The required URLs have default values for Office 365. Upon saving, the user will be redirected to the external sign in. After signing in, a token should become available, which must then be saved again. Any modification to the Tenant ID, Client ID, and/or Client Secret will redirect the user back to the external sign-in screen after saving.
PHPMailer will be used to send emails when XOAUTH2 is used.
This change does require Composer.